### PR TITLE
Strengthen the types

### DIFF
--- a/lib/db/models/ad-set.ts
+++ b/lib/db/models/ad-set.ts
@@ -16,7 +16,7 @@ export interface ITargeting {
   interests?: string[];
   customAudiences?: string[];
   lookalikes?: string[];
-  exclusions?: Record<string, any>;
+  exclusions?: string[] | Record<string, unknown>;
 }
 
 export interface IAdSet extends Document {

--- a/lib/db/models/ad.ts
+++ b/lib/db/models/ad.ts
@@ -22,7 +22,7 @@ export interface IAdCreative {
   body?: string;
   callToAction?: string;
   linkUrl?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface IAd extends Document {

--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -17,13 +17,20 @@ function getTokenFromHeaders(req: IncomingMessage): string | null {
   return null;
 }
 
+interface JwtPayload {
+  userId?: string;
+  tenantId?: string;
+  email?: string;
+  [key: string]: unknown;
+}
+
 export async function verifyAuth(req: IncomingMessage): Promise<AuthUser | null> {
   const secret = process.env.NEXTAUTH_SECRET;
   if (!secret) return null;
   const token = getTokenFromHeaders(req);
   if (!token) return null;
   try {
-    const payload = jwt.verify(token, secret) as any;
+    const payload = jwt.verify(token, secret) as JwtPayload;
     if (!payload?.userId || !payload?.tenantId || !payload?.email) return null;
     // Only select the plan field for efficiency
     const tenant = await TenantModel.findOne({ tenantId: payload.tenantId }).select('plan').lean();
@@ -35,7 +42,20 @@ export async function verifyAuth(req: IncomingMessage): Promise<AuthUser | null>
 }
 
 // Minimal handler types to avoid Next.js dependency
-type MinimalHandler = (req: IncomingMessage & { [key: string]: any }, res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body?: any) => void }) => any | Promise<any>;
+interface AuthenticatedRequest extends IncomingMessage {
+  user?: AuthUser;
+}
+
+interface MinimalResponse {
+  statusCode: number;
+  setHeader: (key: string, value: string) => void;
+  end: (body?: string) => void;
+}
+
+type MinimalHandler = (
+  req: AuthenticatedRequest,
+  res: MinimalResponse
+) => void | Promise<void>;
 
 export function requireAuth(handler: MinimalHandler): MinimalHandler {
   return async (req, res) => {
@@ -46,7 +66,7 @@ export function requireAuth(handler: MinimalHandler): MinimalHandler {
       res.end(JSON.stringify({ status: 'error', code: 'UNAUTHORIZED', message: 'Authentication required' }));
       return;
     }
-    (req as any).user = user;
+    req.user = user;
     return handler(req, res);
   };
 }

--- a/lib/middleware/error-handler.ts
+++ b/lib/middleware/error-handler.ts
@@ -4,27 +4,27 @@ import logger from '../utils/logger';
 export class AppError extends Error {
   statusCode: number;
   code: string;
-  details?: any;
+  details?: unknown;
   isOperational: boolean;
-  constructor(message: string, statusCode = 500, code = 'INTERNAL', details?: any, isOperational = true) {
+  constructor(message: string, statusCode = 500, code = 'INTERNAL', details?: unknown, isOperational = true) {
     super(message);
     this.statusCode = statusCode;
     this.code = code;
     this.details = details;
     this.isOperational = isOperational;
   }
-  static badRequest(message = 'Bad Request', details?: any) { return new AppError(message, 400, 'BAD_REQUEST', details); }
-  static unauthorized(message = 'Unauthorized', details?: any) { return new AppError(message, 401, 'UNAUTHORIZED', details); }
-  static forbidden(message = 'Forbidden', details?: any) { return new AppError(message, 403, 'FORBIDDEN', details); }
-  static notFound(message = 'Not Found', details?: any) { return new AppError(message, 404, 'NOT_FOUND', details); }
-  static internal(message = 'Internal Server Error', details?: any) { return new AppError(message, 500, 'INTERNAL', details); }
+  static badRequest(message = 'Bad Request', details?: unknown) { return new AppError(message, 400, 'BAD_REQUEST', details); }
+  static unauthorized(message = 'Unauthorized', details?: unknown) { return new AppError(message, 401, 'UNAUTHORIZED', details); }
+  static forbidden(message = 'Forbidden', details?: unknown) { return new AppError(message, 403, 'FORBIDDEN', details); }
+  static notFound(message = 'Not Found', details?: unknown) { return new AppError(message, 404, 'NOT_FOUND', details); }
+  static internal(message = 'Internal Server Error', details?: unknown) { return new AppError(message, 500, 'INTERNAL', details); }
 }
 
 export interface ErrorResponse {
   status: 'error';
   code: string;
   message: string;
-  details?: any;
+  details?: unknown;
   requestId: string;
   timestamp: string;
 }

--- a/lib/services/meta-oauth/oauth-service.ts
+++ b/lib/services/meta-oauth/oauth-service.ts
@@ -292,7 +292,13 @@ export async function saveMetaConnection(
  * Get decrypted access token for a tenant
  */
 export async function getAccessToken(tenantId: string, adAccountId?: string): Promise<string> {
-  const query: any = { tenantId, status: 'ACTIVE' };
+  interface ConnectionQuery {
+    tenantId: string;
+    status: string;
+    adAccountId?: string;
+  }
+
+  const query: ConnectionQuery = { tenantId, status: 'ACTIVE' };
   if (adAccountId) {
     query.adAccountId = adAccountId;
   }
@@ -335,7 +341,12 @@ export async function refreshConnection(tenantId: string, adAccountId?: string):
   const adAccounts = await getUserAdAccounts(accessToken, debugData.user_id);
 
   // Update connection
-  const query: any = { tenantId };
+  interface ConnectionQuery {
+    tenantId: string;
+    adAccountId?: string;
+  }
+
+  const query: ConnectionQuery = { tenantId };
   if (adAccountId) {
     query.adAccountId = adAccountId;
   }
@@ -361,7 +372,12 @@ export async function refreshConnection(tenantId: string, adAccountId?: string):
 export async function revokeConnection(tenantId: string, adAccountId?: string): Promise<void> {
   logger.info('Revoking Meta connection', { tenantId, adAccountId });
 
-  const query: any = { tenantId };
+  interface ConnectionQuery {
+    tenantId: string;
+    adAccountId?: string;
+  }
+
+  const query: ConnectionQuery = { tenantId };
   if (adAccountId) {
     query.adAccountId = adAccountId;
   }

--- a/lib/services/meta-sync/graph-client.ts
+++ b/lib/services/meta-sync/graph-client.ts
@@ -100,8 +100,8 @@ async function fetchJson<T>(
 
     const payload = (await response.json()) as T & { error?: GraphError };
 
-    if (!response.ok || (payload && (payload as any).error)) {
-      const error = (payload as any).error;
+    if (!response.ok || payload.error) {
+      const error = payload.error;
       
       if (error) {
         const apiError = new MetaAPIError(
@@ -185,11 +185,18 @@ async function refreshAccessToken(connection: IMetaConnection): Promise<IMetaCon
   refreshUrl.searchParams.set('client_secret', META_APP_SECRET!);
   refreshUrl.searchParams.set('fb_exchange_token', refreshToken);
 
-  const refreshResponse = await fetch(refreshUrl.toString());
-  const refreshPayload = (await refreshResponse.json()) as Record<string, any> & { error?: GraphError };
+  interface RefreshTokenResponse {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+    error?: GraphError;
+  }
 
-  if (!refreshResponse.ok || refreshPayload?.error) {
-    const error = refreshPayload?.error;
+  const refreshResponse = await fetch(refreshUrl.toString());
+  const refreshPayload = (await refreshResponse.json()) as RefreshTokenResponse;
+
+  if (!refreshResponse.ok || refreshPayload.error) {
+    const error = refreshPayload.error;
     const message = error ? `${error.code} ${error.message}` : 'Failed to refresh Meta token';
     throw new Error(message);
   }
@@ -278,13 +285,24 @@ export async function fetchInsights<T>(
   return results;
 }
 
+interface BatchRequestItem {
+  method: string;
+  relative_url: string;
+}
+
+interface BatchResponseItem {
+  code: number;
+  headers?: Array<{ name: string; value: string }>;
+  body?: string;
+}
+
 export async function batchRequest(
   accessToken: string,
-  requests: Array<{ method: string; relative_url: string }>,
+  requests: BatchRequestItem[],
   userId?: string
-): Promise<any[]> {
+): Promise<BatchResponseItem[]> {
   const url = buildUrl('', { access_token: accessToken });
-  
+
   if (userId) {
     await checkRateLimit(userId);
   }
@@ -301,7 +319,7 @@ export async function batchRequest(
     throw new MetaAPIError(`Batch request failed with status ${response.status}`, response.status);
   }
 
-  const results = (await response.json()) as any[];
+  const results = (await response.json()) as BatchResponseItem[];
   return results;
 }
 

--- a/lib/services/meta-sync/sync-service.ts
+++ b/lib/services/meta-sync/sync-service.ts
@@ -27,18 +27,68 @@ interface GraphCampaign {
   stop_time?: string;
 }
 
+interface GraphTargeting {
+  app_store_audience_size?: number;
+  age_min?: number;
+  age_max?: number;
+  genders?: number[];
+  geo_locations?: {
+    countries?: Array<{ key: string } | string>;
+  };
+  interests?: Array<{ name: string }>;
+  custom_audiences?: string[];
+  lookalike_specs?: Array<{ name: string }>;
+  excluded_custom_audiences?: string[];
+}
+
+interface GraphDeliveryInfo {
+  status?: string;
+  daily_spend?: string | number;
+}
+
 interface GraphAdSet {
   id: string;
   name: string;
   status?: string;
   daily_budget?: string;
-  targeting?: Record<string, any>;
+  targeting?: GraphTargeting;
   optimization_goal?: string;
   learning_phase_status?: string;
   start_time?: string;
   end_time?: string;
   campaign_id?: string;
-  delivery_info?: Record<string, any>;
+  delivery_info?: GraphDeliveryInfo;
+}
+
+interface GraphCreative {
+  id?: string;
+  asset_feed_spec?: {
+    attachment_style?: string;
+  };
+  object_story_spec?: {
+    link_data?: {
+      link?: string;
+      call_to_action?: {
+        type?: string;
+      };
+    };
+  };
+  title?: string;
+  headline?: string;
+  name?: string;
+  body?: string;
+  message?: string;
+  call_to_action?: {
+    type?: string;
+  };
+  link_url?: string;
+}
+
+interface GraphAdIssue {
+  error_code: number;
+  error_message: string;
+  error_summary: string;
+  level: string;
 }
 
 interface GraphAd {
@@ -47,13 +97,8 @@ interface GraphAd {
   status?: string;
   effective_status?: string;
   adset_id?: string;
-  creative?: Record<string, any>;
-  issues_info?: Array<{
-    error_code: number;
-    error_message: string;
-    error_summary: string;
-    level: string;
-  }>;
+  creative?: GraphCreative;
+  issues_info?: GraphAdIssue[];
 }
 
 interface GraphInsights {
@@ -171,14 +216,14 @@ function normalizeAdEffectiveStatus(status?: string): string {
   return adEffectiveStatusMap[status] || 'PAUSED';
 }
 
-function mapTargeting(targeting?: Record<string, any>): ITargeting {
+function mapTargeting(targeting?: GraphTargeting): ITargeting {
   if (!targeting) {
     return {};
   }
 
-  const countries:
-    | string[]
-    | undefined = targeting.geo_locations?.countries?.map((c: any) => c.key) ?? targeting.geo_locations?.countries;
+  const countries = targeting.geo_locations?.countries?.map((c) =>
+    typeof c === 'string' ? c : c.key
+  );
   const locations: string[] = [];
   if (countries) {
     locations.push(...countries.filter(Boolean));
@@ -190,25 +235,34 @@ function mapTargeting(targeting?: Record<string, any>): ITargeting {
     ageMax: targeting.age_max,
     genders: targeting.genders,
     locations,
-    interests: targeting.interests?.map((interest: any) => interest.name),
+    interests: targeting.interests?.map((interest) => interest.name),
     customAudiences: targeting.custom_audiences,
-    lookalikes: targeting.lookalike_specs?.map((lookalike: any) => lookalike.name),
+    lookalikes: targeting.lookalike_specs?.map((lookalike) => lookalike.name),
     exclusions: targeting.excluded_custom_audiences,
   };
 }
 
-function mapCreative(creative?: Record<string, any>): Record<string, any> {
+interface MappedCreative {
+  creativeId?: string;
+  type?: string;
+  headline?: string;
+  body?: string;
+  callToAction?: string;
+  linkUrl?: string;
+  metadata: GraphCreative;
+}
+
+function mapCreative(creative?: GraphCreative): MappedCreative {
   if (!creative) {
-    return {};
+    return { metadata: {} };
   }
 
   return {
     creativeId: creative.id,
-    type: creative.asset_feed_spec?.attachment_style || creative.object_story_spec?.link_data?.link, // best effort
+    type: creative.asset_feed_spec?.attachment_style || creative.object_story_spec?.link_data?.link,
     headline: creative.title || creative.headline || creative.name,
     body: creative.body || creative.message,
-    callToAction:
-      (creative.object_story_spec?.link_data?.call_to_action?.type as string) || creative.call_to_action?.type,
+    callToAction: creative.object_story_spec?.link_data?.call_to_action?.type || creative.call_to_action?.type,
     linkUrl: creative.link_url || creative.object_story_spec?.link_data?.link,
     metadata: creative,
   };
@@ -279,15 +333,22 @@ export async function upsertAdFromGraph(payload: GraphAd, accountId: string, cam
   }).exec();
 }
 
-function mapIssues(effectiveStatus?: string, issuesInfo?: Array<any>) {
-  const issues: Array<any> = [];
+interface MappedAdIssue {
+  errorCode: string;
+  errorMessage: string;
+  errorSummary?: string;
+  level: 'ERROR' | 'WARNING';
+}
+
+function mapIssues(effectiveStatus?: string, issuesInfo?: GraphAdIssue[]): MappedAdIssue[] {
+  const issues: MappedAdIssue[] = [];
 
   if (issuesInfo && issuesInfo.length > 0) {
     issues.push(...issuesInfo.map(issue => ({
       errorCode: String(issue.error_code),
       errorMessage: issue.error_message,
       errorSummary: issue.error_summary,
-      level: issue.level === 'ERROR' ? 'ERROR' : 'WARNING',
+      level: (issue.level === 'ERROR' ? 'ERROR' : 'WARNING') as 'ERROR' | 'WARNING',
     })));
   }
 
@@ -708,7 +769,7 @@ export async function syncPerformanceDataForCampaign(
       'date_stop',
     ];
 
-    const insights = await fetchInsights<any>(
+    const insights = await fetchInsights<GraphInsights>(
       accessToken,
       campaignId,
       {
@@ -762,7 +823,7 @@ export async function syncPerformanceDataForAdSet(
       'date_stop',
     ];
 
-    const insights = await fetchInsights<any>(
+    const insights = await fetchInsights<GraphInsights>(
       accessToken,
       adSetId,
       {
@@ -815,7 +876,7 @@ export async function syncPerformanceDataForAd(
       'date_stop',
     ];
 
-    const insights = await fetchInsights<any>(
+    const insights = await fetchInsights<GraphInsights>(
       accessToken,
       adId,
       {

--- a/lib/webhooks/meta.ts
+++ b/lib/webhooks/meta.ts
@@ -19,9 +19,14 @@ export interface MetaWebhookEntry {
   changes?: MetaWebhookChange[];
 }
 
+export interface MetaWebhookChangeValue {
+  id?: string;
+  [key: string]: unknown;
+}
+
 export interface MetaWebhookChange {
   field: 'ad' | 'adset' | 'campaign' | string;
-  value: Record<string, any>;
+  value: MetaWebhookChangeValue;
 }
 
 const APP_SECRET = process.env.META_APP_SECRET;


### PR DESCRIPTION
Replace weak 'any' types with proper type annotations:

- sync-service.ts: Add GraphTargeting, GraphDeliveryInfo, GraphCreative, GraphAdIssue, MappedCreative, and MappedAdIssue interfaces
- graph-client.ts: Add RefreshTokenResponse, BatchRequestItem, and BatchResponseItem interfaces
- oauth-service.ts: Replace 'any' query objects with ConnectionQuery interface
- auth.ts: Add JwtPayload, AuthenticatedRequest, and MinimalResponse interfaces
- error-handler.ts: Replace 'any' with 'unknown' for error details
- ad-set.ts: Update ITargeting.exclusions to use 'unknown' instead of 'any'
- ad.ts: Update IAdCreative.metadata to use 'unknown' instead of 'any'
- webhooks/meta.ts: Add MetaWebhookChangeValue interface

All changes maintain backward compatibility while providing better type safety.

# Summary

Describe the purpose and context of this change.

## Changes

- List key changes
- Libraries, APIs, or migrations

## Tests

- What tests were added/updated?
- Local run results or CI evidence

## Risks & Rollback

- Potential impact areas
- How to rollback

## Checklist

- [x] Branch is up to date with main
- [x] CI passes (lint, typecheck, build, tests)
- [x] Docs/README updated if needed
- [x] Secrets are not committed
- [x] Squash merge is acceptable
